### PR TITLE
Changed filter to become 'tags.tag'

### DIFF
--- a/src/main/java/io/tackle/applicationinventory/entities/Application.java
+++ b/src/main/java/io/tackle/applicationinventory/entities/Application.java
@@ -10,9 +10,13 @@ import org.hibernate.annotations.Where;
 import java.util.Set;
 import java.util.HashSet;
 
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.persistence.ElementCollection;
+import javax.persistence.UniqueConstraint;
 import java.util.Objects;
 
 @Entity
@@ -30,7 +34,13 @@ public class Application extends AbstractEntity {
     public String comments;
 
     @ElementCollection
-    @Filterable(filterName = "tags.id")
+    @CollectionTable(
+            name = "Application_tags",
+            joinColumns = @JoinColumn(name = "Application_id"),
+            uniqueConstraints = @UniqueConstraint(columnNames = {"Application_id", "tag"})
+    )
+    @Column(name = "tag")
+    @Filterable(filterName = "tags.tag", check = CheckType.EQUAL)
     public Set<String> tags = new HashSet<>();
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,10 @@ quarkus.hibernate-orm.log.sql=false
 # bind-parameters (BasicBinder) is at TRACE so min-level must be configured properly
 %dev.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".min-level=FINER
 %dev.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".level=FINER
+# SQL queries with variable bindings useful during local testing in case of issues to debug
+#%test.quarkus.hibernate-orm.log.sql=true
+#%test.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".min-level=FINER
+#%test.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".level=FINER
 
 # use 'update' to generate SQL scripts, validate them and then create a new file into resources/db/migration folder
 %dev.quarkus.hibernate-orm.database.generation = drop-and-create

--- a/src/main/resources/db/migration/V20210329.1__create_application_tags.sql
+++ b/src/main/resources/db/migration/V20210329.1__create_application_tags.sql
@@ -1,4 +1,4 @@
 create table Application_tags (
        Application_id int8 not null,
-        tags varchar(255)
+        tag varchar(255)
     )

--- a/src/main/resources/db/migration/V20210329.2__alter_application_tags.sql
+++ b/src/main/resources/db/migration/V20210329.2__alter_application_tags.sql
@@ -3,4 +3,4 @@ alter table if exists Application_tags
        foreign key (Application_id) 
        references application;
 alter table if exists Application_tags
-    add constraint UKajtkwngylkio3007ksyreg2yu unique (Application_id, tags);
+    add constraint UK5adrofcv3ygl80g2lyh240u31 unique (Application_id, tag);

--- a/src/main/resources/db/test-data/V20210329.3__insert_application_tags.sql
+++ b/src/main/resources/db/test-data/V20210329.3__insert_application_tags.sql
@@ -1,4 +1,4 @@
-INSERT INTO Application_tags (Application_id, tags) VALUES (1, '531');
-INSERT INTO Application_tags (Application_id, tags) VALUES (1, '7');
-INSERT INTO Application_tags (Application_id, tags) VALUES (1, '112');
-INSERT INTO Application_tags (Application_id, tags) VALUES (2, '531');
+INSERT INTO Application_tags (Application_id, tag) VALUES (1, '531');
+INSERT INTO Application_tags (Application_id, tag) VALUES (1, '7');
+INSERT INTO Application_tags (Application_id, tag) VALUES (1, '712');
+INSERT INTO Application_tags (Application_id, tag) VALUES (2, '531');

--- a/src/test/java/io/tackle/applicationinventory/resources/ApplicationTest.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/ApplicationTest.java
@@ -72,7 +72,7 @@ public class ApplicationTest extends SecuredResourceTest {
     public void testTagIDFilteredSingleParamListHalEndpoint() {
         given()
                 .accept("application/hal+json")
-                .queryParam("tags.id", "7")
+                .queryParam("tags.tag", "7")
                 .when().get(PATH)
                 .then()
                 .log().all()


### PR DESCRIPTION
- filterName changed to "tags.tag" because `id` was misleading for JPA query creation
- added the newly available `check = CheckType.EQUAL` (from https://github.com/konveyor/tackle-commons-rest/pull/35)
- explicit JPA management of the `CollectionTable` for `tags` to get full control of the names, unique constraint and column's name
- added commented properties useful for tests debugging to have SQL queries and param bindings
