### PR TITLE
Workaround to have a list of ImportSummaryDto wrapped in HAL response

### DIFF
--- a/src/main/java/io/tackle/applicationinventory/resources/ImportSummaryResource.java
+++ b/src/main/java/io/tackle/applicationinventory/resources/ImportSummaryResource.java
@@ -2,9 +2,15 @@ package io.tackle.applicationinventory.resources;
 
 import io.tackle.applicationinventory.dto.ImportSummaryDto;
 import io.tackle.applicationinventory.services.ImportSummaryService;
+import io.tackle.commons.resources.hal.HalCollectionEnrichedWrapper;
+import org.jboss.resteasy.links.LinkResource;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.List;
 
 @Path("import-summary")
@@ -12,11 +18,24 @@ public class ImportSummaryResource {
     @Inject
     ImportSummaryService svc;
 
-
     @Path("summary")
-    @Produces("application/hal+json")
+    @Produces("application/json")
     @GET
     public List<ImportSummaryDto> getImportSummary() {
         return svc.getSummary();
+    }
+
+    @Produces("application/hal+json")
+    @GET
+    @LinkResource(
+            entityClassName = "io.tackle.applicationinventory.dto.ImportSummaryDto",
+            rel = "list"
+    )
+    public Response getImportSummaryHal() {
+        final List<ImportSummaryDto> importSummaryDtoList = svc.getSummary();
+        final HalCollectionEnrichedWrapper halCollectionEnrichedWrapper =
+                new HalCollectionEnrichedWrapper(Collections.unmodifiableCollection(importSummaryDtoList),
+                        ImportSummaryDto.class, "import-summary", importSummaryDtoList.size());
+        return Response.ok(halCollectionEnrichedWrapper).build();
     }
 }

--- a/src/test/java/io/tackle/applicationimporter/ImportServiceTest.java
+++ b/src/test/java/io/tackle/applicationimporter/ImportServiceTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -270,7 +271,17 @@ public class ImportServiceTest extends SecuredResourceTest {
         ApplicationImport refusedImport4 = ApplicationImport.findById(id4);
         assertEquals(Boolean.FALSE, refusedImport4.getValid());
         ApplicationImport refusedImport5 = ApplicationImport.findById(id5);
-        assertEquals(Boolean.FALSE, refusedImport4.getValid());
+        assertEquals(Boolean.FALSE, refusedImport5.getValid());
+
+        given()
+                .accept("application/hal+json")
+                .when()
+                .get("/import-summary")
+                .then()
+                .statusCode(200)
+                .body("_embedded.import-summary.size()", is(1),
+                "_embedded.import-summary.invalidCount", containsInRelativeOrder(5),
+                        "total_count", is(1));
 
         userTransaction.begin();
         ApplicationImport.deleteAll();


### PR DESCRIPTION
- the HAL endpoint is exposed at `/import-summary`
- the collection within `_embedded` in the response is going to be called `import-summary`
- added a basic test to cover this